### PR TITLE
Build out /api/v1/users/<email>/resetpassword endpoint to handle password reset functionality

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import express from 'express';
 import bodyParser from 'body-parser';
 import dotenv from 'dotenv';

--- a/server/middlewares/validateUser.js
+++ b/server/middlewares/validateUser.js
@@ -66,4 +66,27 @@ export default class userValidate {
       });
     });
   }
+
+  static resetPassword(req, res, next) {
+    const user = req.body;
+
+    const userProperties = {
+      oldPassword: 'alpha_dash|min:6|max:16',
+      newPassword: 'required|alpha_dash|min:6|max:16',
+      confirmPassword: 'required|alpha_dash|min:6|max:16',
+    };
+
+    const validator = new Validator(user,
+      userProperties,
+      customErrorMsgs);
+
+    validator.passes(() => next());
+    validator.fails(() => {
+      const errors = validator.errors.all();
+      return res.status(400).json({
+        status: 400,
+        error: errors,
+      });
+    });
+  }
 }

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -26,6 +26,21 @@ export default class User {
     }
   }
 
+  static async resetPassword(password, email) {
+    const queryString = `UPDATE users
+    SET password=$1
+    WHERE email=$2
+    RETURNING *;`;
+    const values = [password, email];
+
+    try {
+      const { rows } = await pool.query(queryString, values);
+      return rows[0];
+    } catch (error) {
+      return error.message;
+    }
+  }
+
   async createStaff() {
     const type = 'staff';
     const isadmin = false;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import accountRouter from './accountRoute';
-// import transactionRouter from './transactionRoute';
+import transactionRouter from './transactionRoute';
 import userRouter from './userRoute';
 
 const router = new Router();
@@ -12,7 +12,7 @@ router.get('/api/v1', (req, res) => {
 });
 
 router.use('/api/v1/accounts', accountRouter);
-// router.use('/api/v1/transactions', transactionRouter);
+router.use('/api/v1/transactions', transactionRouter);
 router.use('/api/v1', userRouter);
 
 export default router;

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -8,7 +8,7 @@ import paramsValidate from '../middlewares/validateParams';
 const userRouter = new Router();
 const {
   signUp, signin, allUserAccounts,
-  createStaff, createAdmin,
+  createStaff, createAdmin, resetPassword,
 } = userController;
 
 userRouter.post('/auth/signup',
@@ -32,5 +32,11 @@ userRouter.get('/user/:email/accounts',
   requireAuth, staffAuth,
   paramsValidate.email,
   allUserAccounts);
+
+userRouter.post('/user/:email/resetpassword',
+  requireAuth,
+  paramsValidate.email,
+  userValidate.resetPassword,
+  resetPassword);
 
 export default userRouter;

--- a/server/tests/testData.js
+++ b/server/tests/testData.js
@@ -163,6 +163,30 @@ const login = {
   password: 'asdfghjkl',
 };
 
+const resetPasswordDetails = {
+  oldPassword: 'edepassword',
+  newPassword: 'edepassword1',
+  confirmPassword: 'edepassword1',
+};
+
+const wrongOldPassword = {
+  oldPassword: 'wrongoldpassword',
+  newPassword: 'edepassword1',
+  confirmPassword: 'edepassword1',
+};
+
+const similarNewPassword = {
+  oldPassword: 'edepassword1',
+  newPassword: 'edepassword1',
+  confirmPassword: 'edepassword',
+};
+
+const unmatchingNewAndConfirm = {
+  oldPassword: 'edepassword1',
+  newPassword: 'edepassword10',
+  confirmPassword: 'edepassword11',
+};
+
 // Account
 const emptyAccountType = {
   type: '',
@@ -218,4 +242,5 @@ export {
   emptyClient, emptyLogin, emptyStaff, emptyTestAdmin, emptytransaction,
   login, accountType, transaction, testAdmin, clientField2, adminField2, staffField2,
   clientField3, clientField4, staffField3, staffField4, adminField3, adminField4, adminField5,
+  resetPasswordDetails, wrongOldPassword, similarNewPassword, unmatchingNewAndConfirm,
 };


### PR DESCRIPTION
#### What does this PR do?
Contributes to already existing codebase by adding functionality for users to reset their password

#### Description of Task to be completed?
- add route and controller for password-reset functionality
- write integration tests for the new functionality

#### How should this be manually tested?
- clone the repo
- set up postgres database
- run 'npm run dbtest' on the command line to seed the database
- run 'npm test' on the command line for automated tests
- open Postman and test the reset-password route

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

